### PR TITLE
fix: 🚰 OOM on large files, broken listing with special chars and wide dirs

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import html
 import io
 from datetime import datetime
 import keyword
@@ -12,7 +13,7 @@ import socket
 import token
 import tokenize
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
+from urllib.parse import quote, unquote
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -330,11 +331,14 @@ def generate_directory_listing(path: pathlib.Path) -> bytes:
     # Parent always on top (separate class + excluded from sorting/filter)
     if path != ROOT:
         parent_rel = path.parent.relative_to(ROOT)
+        parent_href = html.escape(
+            "/" + quote(str(parent_rel), safe="/") + "/", quote=True
+        )
         rows.append(f"""
           <tr class="parent-row" data-name=".." data-size="0" data-ts="{int(path.stat().st_mtime)}" data-isdir="1" data-parent="1">
             <td class="name-col">
               <span class="icon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M10 4l2 2h8a2 2 0 012 2v9a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h6z"/></svg></span>
-              <a href="/{parent_rel}/">..</a>
+              <a href="{parent_href}">..</a>
               <span class="meta">Parent</span>
             </td>
             <td class="meta">—</td>
@@ -345,7 +349,10 @@ def generate_directory_listing(path: pathlib.Path) -> bytes:
     for item in sorted(path.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
         is_dir = item.is_dir()
         rel_item = item.relative_to(ROOT)
-        href = f"/{rel_item}/" if is_dir else f"/{rel_item}"
+        raw_href = "/" + quote(str(rel_item), safe="/") + ("/" if is_dir else "")
+        href = html.escape(raw_href, quote=True)
+        name = html.escape(item.name)
+        data_name = html.escape(item.name, quote=True)
         size = item.stat().st_size if not is_dir else 0
         mtime = int(item.stat().st_mtime)
         size_str = "—" if is_dir else format_size(size)
@@ -360,8 +367,8 @@ def generate_directory_listing(path: pathlib.Path) -> bytes:
         """
         )
         rows.append(f"""
-          <tr data-name="{item.name}" data-size="{size}" data-ts="{mtime}" data-isdir="{1 if is_dir else 0}">
-            <td class="name-col">{icon}<a class="file-link" href="{href}">{item.name}{"/" if is_dir else ""}</a></td>
+          <tr data-name="{data_name}" data-size="{size}" data-ts="{mtime}" data-isdir="{1 if is_dir else 0}">
+            <td class="name-col">{icon}<a class="file-link" href="{href}">{name}{"/" if is_dir else ""}</a></td>
             <td class="meta">{size_str}</td>
             <td class="meta">{mod_str}</td>
           </tr>
@@ -515,8 +522,8 @@ def generate_directory_listing(path: pathlib.Path) -> bytes:
 })();
 """
     body = table
-    html = render_page(f"Directory listing for /{rel}", body, extra_js=js)
-    return html.encode("utf-8")
+    page = render_page(f"Directory listing for /{rel}", body, extra_js=js)
+    return page.encode("utf-8")
 
 
 def render_page(
@@ -527,7 +534,7 @@ def render_page(
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>{title}</title>
+<title>{html.escape(title)}</title>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%233f51b5'><path d='M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6zM14 3.5L18.5 8H14V3.5z'/></svg>" type="image/svg+xml">
 <style>
 :root {{

--- a/server.py
+++ b/server.py
@@ -611,6 +611,7 @@ thead th {{
   padding: 10px 12px; border-bottom: 1px solid var(--border); cursor: pointer; white-space: nowrap;
 }}
 tbody td {{ padding: 12px; border-bottom: 1px solid var(--border); vertical-align: middle; }}
+tbody td:nth-child(n+2) {{ white-space: nowrap; width: 1%; }}
 tbody tr:hover {{ background: color-mix(in oklab, var(--card) 80%, var(--accent) 10%); }}
 
 .name-col {{ display: flex; align-items: center; gap: 10px; }}

--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@ import logging
 import mimetypes
 import pathlib
 import re
+import socket
 import token
 import tokenize
 from typing import TYPE_CHECKING
@@ -928,6 +929,20 @@ async def attempt_server(port: int, host: str) -> tuple[int, asyncio.AbstractSer
     return port, server
 
 
+def _print_startup_urls(host: str, port: int) -> None:
+    lines = [f"  Local:    http://localhost:{port}"]
+    if host == "0.0.0.0":
+        try:
+            ip = socket.gethostbyname(socket.gethostname())
+            if ip and ip != "127.0.0.1":
+                lines.append(f"  Network:  http://{ip}:{port}")
+        except OSError:
+            pass
+    else:
+        lines.append(f"  Network:  http://{host}:{port}")
+    print("\n" + "\n".join(lines) + "\n", flush=True)
+
+
 async def run_server_on_available_port(
     host: str = "0.0.0.0",
     ports: Iterable[int] = (9000,),
@@ -935,28 +950,26 @@ async def run_server_on_available_port(
     """Attempt to start servers on multiple ports concurrently.
     Use the first one that passes the ping tests and cancel the rest.
     """
+    # Silence per-connection INFO logs produced by self-ping health checks.
+    logging.disable(logging.INFO)
     tasks = [asyncio.create_task(attempt_server(port, host)) for port in ports]
 
     for completed in asyncio.as_completed(tasks):
         try:
             port, server = await completed
-            logger.info(
-                "Server started and passed ping tests on http://%s:%s",
-                host,
-                port,
-            )
-            # Cancel any other pending tasks.
             for task in tasks:
                 if not task.done():
                     task.cancel()
-            # Start serving on the successful server.
+            logging.disable(logging.NOTSET)
+            _print_startup_urls(host, port)
             async with server:
                 await server.serve_forever()
             return
         except Exception as e:
             logger.warning("Attempt failed: %s", e)
 
-    logger.error("No available ports found that passed ping tests. Exiting.")
+    logging.disable(logging.NOTSET)
+    logger.error("No available ports found. Exiting.")
 
 
 if __name__ == "__main__":

--- a/server.py
+++ b/server.py
@@ -25,9 +25,11 @@ logger = logging.getLogger(__name__)
 
 ROOT = pathlib.Path(__file__).parent.resolve()
 ALLOWED_METHODS = {"GET", "HEAD"}
-BUFFER_SIZE = 1024
 MAX_HEADER_SIZE = 8192  # 8KB
 FILE_CHUNK_SIZE = 64 * 1024
+# Markdown above this size is streamed verbatim instead of rendered,
+# since rendering keeps several copies of the text in memory.
+MAX_MARKDOWN_BYTES = 5 * 1024 * 1024
 KB = 1024
 
 
@@ -302,7 +304,7 @@ def parse_request(req: str) -> dict:
     }
 
 
-def validate_path(request_path: str) -> pathlib.Path:
+def validate_path(request_path: str) -> pathlib.Path | None:
     """Validate and resolve requested path against root directory."""
     try:
         requested = ROOT.joinpath(request_path.lstrip("/")).resolve()
@@ -826,7 +828,10 @@ async def handle_client(
                         response = headers + (
                             b"" if request["method"] == "HEAD" else body
                         )
-                elif resolved_path.suffix.lower() == ".md":
+                elif (
+                    resolved_path.suffix.lower() == ".md"
+                    and resolved_path.stat().st_size <= MAX_MARKDOWN_BYTES
+                ):
                     try:
                         md_text = resolved_path.read_text(encoding="utf-8")
                         rendered_html = render_markdown(md_text)
@@ -838,6 +843,7 @@ async def handle_client(
                         logger.exception("Markdown render error")
                         response = b"HTTP/1.1 500 Internal Server Error\r\n\r\n"
                     else:
+                        del md_text, rendered_html
                         headers, body = create_response(
                             request,
                             content,

--- a/server.py
+++ b/server.py
@@ -937,15 +937,110 @@ async def attempt_server(port: int, host: str) -> tuple[int, asyncio.AbstractSer
     return port, server
 
 
+def _network_ips() -> list[str]:
+    """Return IPv4 addresses of all active network interfaces.
+
+    Uses getifaddrs() via ctypes (no hardcoded addresses, no subprocess,
+    stdlib-only). Falls back to a UDP routing probe if ctypes is unavailable.
+    """
+    try:
+        return _ips_via_getifaddrs()
+    except Exception:
+        return _ips_via_udp_probe()
+
+
+def _ips_via_getifaddrs() -> list[str]:
+    import ctypes
+    import ctypes.util
+
+    lib = ctypes.util.find_library("c")
+    if not lib:
+        raise OSError("libc not found")
+    libc = ctypes.CDLL(lib)
+
+    # sockaddr differs between BSD (macOS) and Linux:
+    # BSD prepends a 1-byte sa_len field before sa_family.
+    import sys
+
+    _bsd = sys.platform == "darwin" or "bsd" in sys.platform
+
+    class _SockaddrBSD(ctypes.Structure):
+        _fields_ = [
+            ("sa_len", ctypes.c_uint8),
+            ("sa_family", ctypes.c_uint8),
+            ("sa_data", ctypes.c_char * 14),
+        ]
+
+    class _SockaddrLinux(ctypes.Structure):
+        _fields_ = [
+            ("sa_family", ctypes.c_uint16),
+            ("sa_data", ctypes.c_char * 14),
+        ]
+
+    Sockaddr = _SockaddrBSD if _bsd else _SockaddrLinux
+
+    class IfAddrs(ctypes.Structure):
+        pass
+
+    IfAddrs._fields_ = [
+        ("ifa_next", ctypes.POINTER(IfAddrs)),
+        ("ifa_name", ctypes.c_char_p),
+        ("ifa_flags", ctypes.c_uint),
+        ("ifa_addr", ctypes.POINTER(Sockaddr)),
+        ("ifa_netmask", ctypes.POINTER(Sockaddr)),
+        ("ifa_broadaddr", ctypes.POINTER(Sockaddr)),
+        ("ifa_data", ctypes.c_void_p),
+    ]
+
+    head = ctypes.POINTER(IfAddrs)()
+    if libc.getifaddrs(ctypes.byref(head)) != 0:
+        raise OSError("getifaddrs failed")
+
+    # In sockaddr_in, sin_addr sits at offset 4 from the start of the struct
+    # (sa_len/sa_family=2B + sin_port=2B on both BSD and Linux).
+    _SINADDR_OFF = 4
+
+    ips: list[str] = []
+    seen: set[str] = set()
+    cur = head
+    try:
+        while cur:
+            ifa = cur.contents
+            if ifa.ifa_addr and ifa.ifa_addr.contents.sa_family == socket.AF_INET:
+                addr = ctypes.addressof(ifa.ifa_addr.contents)
+                ip = socket.inet_ntoa(ctypes.string_at(addr + _SINADDR_OFF, 4))
+                if ip != "127.0.0.1" and ip not in seen:
+                    seen.add(ip)
+                    ips.append(ip)
+            cur = ifa.ifa_next
+    finally:
+        libc.freeifaddrs(head)
+
+    return ips
+
+
+def _ips_via_udp_probe() -> list[str]:
+    """Fallback: derive IPs from routing table via zero-packet UDP connects."""
+    seen: set[str] = set()
+    ips: list[str] = []
+    for dest in ("10.255.255.255", "172.31.255.255", "192.168.255.255"):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                s.connect((dest, 1))
+                ip = s.getsockname()[0]
+                if ip and ip != "127.0.0.1" and ip not in seen:
+                    seen.add(ip)
+                    ips.append(ip)
+        except OSError:
+            pass
+    return ips
+
+
 def _print_startup_urls(host: str, port: int) -> None:
     lines = [f"  Local:    http://localhost:{port}"]
     if host == "0.0.0.0":
-        try:
-            ip = socket.gethostbyname(socket.gethostname())
-            if ip and ip != "127.0.0.1":
-                lines.append(f"  Network:  http://{ip}:{port}")
-        except OSError:
-            pass
+        for ip in _network_ips():
+            lines.append(f"  Network:  http://{ip}:{port}")
     else:
         lines.append(f"  Network:  http://{host}:{port}")
     print("\n" + "\n".join(lines) + "\n", flush=True)

--- a/server.py
+++ b/server.py
@@ -27,6 +27,7 @@ ROOT = pathlib.Path(__file__).parent.resolve()
 ALLOWED_METHODS = {"GET", "HEAD"}
 BUFFER_SIZE = 1024
 MAX_HEADER_SIZE = 8192  # 8KB
+FILE_CHUNK_SIZE = 64 * 1024
 KB = 1024
 
 
@@ -192,12 +193,16 @@ def render_markdown(markdown_text: str) -> str:
         # reference-style images/links
         line = re.sub(
             r"!\[([^\]]*?)\]\[([^\]]+)\]",
-            lambda m: f'<img alt="{m.group(1)}" src="{ref_links.get(m.group(2), m.group(2))}" />',
+            lambda m: (
+                f'<img alt="{m.group(1)}" src="{ref_links.get(m.group(2), m.group(2))}" />'
+            ),
             line,
         )
         line = re.sub(
             r"\[([^\]]+)\]\[([^\]]+)\]",
-            lambda m: f'<a href="{ref_links.get(m.group(2), m.group(2))}">{m.group(1)}</a>',
+            lambda m: (
+                f'<a href="{ref_links.get(m.group(2), m.group(2))}">{m.group(1)}</a>'
+            ),
             line,
         )
 
@@ -353,7 +358,7 @@ def generate_directory_listing(path: pathlib.Path) -> bytes:
         )
         rows.append(f"""
           <tr data-name="{item.name}" data-size="{size}" data-ts="{mtime}" data-isdir="{1 if is_dir else 0}">
-            <td class="name-col">{icon}<a class="file-link" href="{href}">{item.name}{'/' if is_dir else ''}</a></td>
+            <td class="name-col">{icon}<a class="file-link" href="{href}">{item.name}{"/" if is_dir else ""}</a></td>
             <td class="meta">{size_str}</td>
             <td class="meta">{mod_str}</td>
           </tr>
@@ -373,7 +378,7 @@ def generate_directory_listing(path: pathlib.Path) -> bytes:
               </tr>
             </thead>
             <tbody>
-              {''.join(rows)}
+              {"".join(rows)}
             </tbody>
           </table>
         </div>
@@ -706,6 +711,58 @@ def create_response(
     return f"{status_line}\r\n{header_lines}\r\n\r\n".encode(), content
 
 
+def build_file_headers(request: dict, file_size: int) -> bytes:
+    """Build response headers for a streamed file, without loading the body."""
+    mime_type, _ = mimetypes.guess_type(request["path"])
+    content_type = mime_type or "application/octet-stream"
+    if content_type.startswith("text/"):
+        content_type += "; charset=utf-8"
+
+    status_line = f"{request['version']} 200 OK"
+    headers = {
+        "Server": "AsyncFileServer/1.0",
+        "Connection": "close",
+        "X-Content-Type-Options": "nosniff",
+        "Content-Type": content_type,
+        "Content-Length": str(file_size),
+    }
+    header_lines = "\r\n".join(f"{k}: {v}" for k, v in headers.items())
+    return f"{status_line}\r\n{header_lines}\r\n\r\n".encode()
+
+
+async def serve_file(
+    writer: asyncio.StreamWriter,
+    request: dict,
+    path: pathlib.Path,
+) -> None:
+    """Stream a file to the writer in fixed-size chunks."""
+    # Open before sending headers so file errors map to proper HTTP statuses.
+    file_obj = path.open("rb")
+    try:
+        file_size = path.stat().st_size
+        writer.write(build_file_headers(request, file_size))
+        await writer.drain()
+        if request["method"] == "HEAD":
+            return
+
+        loop = asyncio.get_running_loop()
+        try:
+            while True:
+                chunk = await loop.run_in_executor(
+                    None,
+                    file_obj.read,
+                    FILE_CHUNK_SIZE,
+                )
+                if not chunk:
+                    break
+                writer.write(chunk)
+                await writer.drain()
+        except (ConnectionResetError, BrokenPipeError) as e:
+            logger.info("Client disconnected during stream: %s", e)
+    finally:
+        file_obj.close()
+
+
 async def handle_client(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
@@ -769,37 +826,43 @@ async def handle_client(
                         response = headers + (
                             b"" if request["method"] == "HEAD" else body
                         )
-                else:
+                elif resolved_path.suffix.lower() == ".md":
                     try:
-                        # If the requested file is Markdown, render it to HTML
-                        if resolved_path.suffix.lower() == ".md":
-                            md_text = resolved_path.read_text(encoding="utf-8")
-                            rendered_html = render_markdown(md_text)
-                            content = rendered_html.encode("utf-8")
-                        else:
-                            content = resolved_path.read_bytes()
+                        md_text = resolved_path.read_text(encoding="utf-8")
+                        rendered_html = render_markdown(md_text)
+                        content = rendered_html.encode("utf-8")
                     except PermissionError as e:
                         logger.warning("Permission denied: %s", e)
                         response = b"HTTP/1.1 403 Forbidden\r\n\r\n"
                     except Exception:
-                        logger.exception("File read error")
+                        logger.exception("Markdown render error")
                         response = b"HTTP/1.1 500 Internal Server Error\r\n\r\n"
                     else:
-                        if resolved_path.suffix.lower() == ".md":
-                            headers, body = create_response(
-                                request,
-                                content,
-                                override_content_type="text/html; charset=utf-8",
-                            )
-                        else:
-                            headers, body = create_response(request, content)
+                        headers, body = create_response(
+                            request,
+                            content,
+                            override_content_type="text/html; charset=utf-8",
+                        )
                         response = headers + (
                             b"" if request["method"] == "HEAD" else body
                         )
+                else:
+                    try:
+                        await serve_file(writer, request, resolved_path)
+                        response = None
+                    except PermissionError as e:
+                        logger.warning("Permission denied: %s", e)
+                        response = b"HTTP/1.1 403 Forbidden\r\n\r\n"
+                    except FileNotFoundError:
+                        logger.warning("File disappeared: %s", resolved_path)
+                        response = b"HTTP/1.1 404 Not Found\r\n\r\n"
+                    except OSError:
+                        logger.exception("File open error")
+                        response = b"HTTP/1.1 500 Internal Server Error\r\n\r\n"
 
-        # Send response
-        writer.write(response)
-        await writer.drain()
+        if response is not None:
+            writer.write(response)
+            await writer.drain()
 
     except Exception:
         logger.exception("Error handling request")


### PR DESCRIPTION
## Changes

**OOM prevention**
- File responses are now streamed in 64 KB chunks with `drain()` backpressure — peak memory per download is O(64 KB) regardless of file size
- Markdown rendering is capped at 5 MB; larger files are streamed verbatim (renderer keeps several in-memory copies)
- File is opened before headers are sent so permission/not-found errors still produce correct HTTP status codes

**Directory listing fixes**
- Filenames with `"`, `<`, `>`, `&` were injected raw into HTML, breaking table rows — now properly escaped with `html.escape()` and `quote()`
- Size and Modified columns no longer wrap in directories with many entries (`white-space: nowrap` + `width: 1%` on those cells)

**Startup output**
- Self-ping INFO logs are suppressed during port probing
- Prints `Local: http://localhost:<port>` (and `Network:` when a LAN IP is detected) instead of the raw bind address

**Misc**
- `validate_path` return type narrowed to `Path | None`